### PR TITLE
update social media links to icons

### DIFF
--- a/index.html
+++ b/index.html
@@ -6,6 +6,7 @@
     <title>repl.it</title>
     <link href="style.css" rel="stylesheet" type="text/css" />
     <style>@import url('https://fonts.googleapis.com/css2?family=Lora&family=Nunito:wght@700&display=swap');</style>
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.7.0/css/font-awesome.min.css">
   </head>
   <body>
     <script src="script.js"></script>

--- a/portfolio.css
+++ b/portfolio.css
@@ -308,3 +308,4 @@ textarea:hover {
 #submit:hover {
   color: #e2dedb;
 }
+


### PR DESCRIPTION
Updated social media links from plain text to social media icons. Still in process of working on since icons are only showing up as circles without the actual logos. CSS sheet is not properly linked so page is currently plain text. 